### PR TITLE
feat(monetization): Phase 5 invoice history and trial periods

### DIFF
--- a/src/lib/server/billing.ts
+++ b/src/lib/server/billing.ts
@@ -187,3 +187,106 @@ export async function syncCheckoutSession(session: Stripe.Checkout.Session) {
   const subscription = await stripe.subscriptions.retrieve(subscriptionId);
   return await syncStripeSubscription(subscription);
 }
+
+// Invoice History
+export interface InvoiceItem {
+  id: string;
+  number: string;
+  amount: number;
+  currency: string;
+  status: Stripe.Invoice.Status;
+  createdAt: Date;
+  dueDate: Date | null;
+  paidAt: Date | null;
+  invoicePdf: string | null;
+  invoiceUrl: string | null;
+  description: string | null;
+}
+
+export async function getCustomerInvoices(
+  stripeCustomerId: string,
+  options?: { limit?: number; startingAfter?: string }
+): Promise<{ invoices: InvoiceItem[]; hasMore: boolean }> {
+  const limit = options?.limit ?? 10;
+  
+  const invoices = await stripe.invoices.list({
+    customer: stripeCustomerId,
+    limit: limit + 1,
+    starting_after: options?.startingAfter,
+  });
+
+  const hasMore = invoices.data.length > limit;
+  const data = hasMore ? invoices.data.slice(0, limit) : invoices.data;
+
+  return {
+    invoices: data.map((invoice) => ({
+      id: invoice.id,
+      number: invoice.number ?? '',
+      amount: invoice.amount_paid ?? invoice.total,
+      currency: invoice.currency.toUpperCase(),
+      status: invoice.status ?? 'draft',
+      createdAt: new Date(invoice.created * 1000),
+      dueDate: invoice.due_date ? new Date(invoice.due_date * 1000) : null,
+      paidAt: invoice.status_transitions?.paid_at 
+        ? new Date(invoice.status_transitions.paid_at * 1000) 
+        : null,
+      invoicePdf: invoice.invoice_pdf,
+      invoiceUrl: invoice.hosted_invoice_url,
+      description: invoice.description ?? invoice.lines.data[0]?.description ?? null,
+    })),
+    hasMore,
+  };
+}
+
+export async function getCustomerUpcomingInvoice(stripeCustomerId: string) {
+  try {
+    const invoice = await stripe.invoices.retrieveUpcoming({
+      customer: stripeCustomerId,
+    });
+
+    return {
+      amount: invoice.amount_remaining,
+      currency: invoice.currency.toUpperCase(),
+      nextPaymentAttempt: invoice.next_payment_attempt 
+        ? new Date(invoice.next_payment_attempt * 1000) 
+        : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// Trial Period Support
+export async function createPremiumCheckoutWithTrial(
+  profile: BillingProfile,
+  origin: string,
+  trialDays: number = 7
+) {
+  const existingSubscription = await getCurrentSubscriptionRecord(profile.id);
+
+  if (existingSubscription && existingSubscription.status && existingSubscriptionStatuses.includes(existingSubscription.status as Stripe.Subscription.Status)) {
+    throw new Error('User already has a subscription record that should be managed through billing portal.');
+  }
+
+  const customerId = await ensureStripeCustomer(profile);
+
+  return await stripe.checkout.sessions.create({
+    mode: 'subscription',
+    customer: customerId,
+    line_items: [{ price: premiumPriceId, quantity: 1 }],
+    allow_promotion_codes: true,
+    success_url: `${origin}/pricing?checkout=success&trial=true`,
+    cancel_url: `${origin}/pricing?checkout=canceled`,
+    metadata: {
+      userId: String(profile.id),
+      ...(profile.supabaseUserId ? { supabaseUserId: profile.supabaseUserId } : {}),
+    },
+    subscription_data: {
+      trial_period_days: trialDays,
+      metadata: {
+        userId: String(profile.id),
+        ...(profile.supabaseUserId ? { supabaseUserId: profile.supabaseUserId } : {}),
+      },
+    },
+  });
+}

--- a/src/pages/api/billing/checkout.ts
+++ b/src/pages/api/billing/checkout.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { createPremiumCheckoutSession, getBillingProfileBySupabaseUserId } from '../../../lib/server/billing';
+import { createPremiumCheckoutSession, createPremiumCheckoutWithTrial, getBillingProfileBySupabaseUserId } from '../../../lib/server/billing';
 import { validateCsrfToken } from '../../../lib/server/csrf';
 import { getSupabaseServerClient } from '../../../lib/supabase';
 
@@ -9,6 +9,7 @@ export const POST: APIRoute = async ({ request, cookies, redirect, url }) => {
   try {
     const formData = await request.formData();
     const csrfToken = formData.get('csrf_token') as string | null;
+    const withTrial = formData.get('trial') === 'true';
 
     if (!validateCsrfToken(cookies, csrfToken)) {
       return redirect('/pricing?billing=invalid-request');
@@ -27,7 +28,9 @@ export const POST: APIRoute = async ({ request, cookies, redirect, url }) => {
       return redirect('/pricing?billing=profile-unavailable');
     }
 
-    const session = await createPremiumCheckoutSession(profile, url.origin);
+    const session = withTrial 
+      ? await createPremiumCheckoutWithTrial(profile, url.origin, 7)
+      : await createPremiumCheckoutSession(profile, url.origin);
 
     if (!session.url) {
       return redirect('/pricing?billing=checkout-error');

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -39,10 +39,13 @@ if (user) {
 
 const checkoutState = Astro.url.searchParams.get('checkout');
 const billingState = Astro.url.searchParams.get('billing');
+const trialState = Astro.url.searchParams.get('trial');
 const csrfToken = getCsrfToken(Astro.cookies);
 
 const feedbackMessage = checkoutState === 'success'
-  ? 'Your checkout was completed. Premium access will appear as soon as Stripe finishes syncing your subscription.'
+  ? trialState === 'true'
+    ? 'Your 7-day free trial has started! Enjoy Premium access with no payment required until the trial ends.'
+    : 'Your checkout was completed. Premium access will appear as soon as Stripe finishes syncing your subscription.'
   : checkoutState === 'canceled'
     ? 'Checkout was canceled. You can restart it anytime.'
     : billingState === 'invalid-request'
@@ -122,8 +125,18 @@ const feedbackType = checkoutState === 'canceled' || billingState ? 'error' : fe
               ) : (
                 <form method="POST" action="/api/billing/checkout" class="space-y-4">
                   <input type="hidden" name="csrf_token" value={csrfToken} />
+                  
+                  <!-- Trial option -->
+                  <label class="flex items-start gap-3 cursor-pointer rounded-xl border border-primary/20 bg-primary/5 p-4 hover:border-primary/40 transition">
+                    <input type="checkbox" name="trial" value="true" class="checkbox checkbox-primary checkbox-sm mt-0.5" checked />
+                    <div class="flex-1">
+                      <span class="font-semibold text-base-content">Start with 7-day free trial</span>
+                      <p class="text-sm text-base-content/60 mt-0.5">Try Premium risk-free. No payment required until the trial ends.</p>
+                    </div>
+                  </label>
+                  
                   <button type="submit" class="btn btn-primary btn-lg w-full">Start Premium Membership</button>
-                  <p class="text-center text-xs text-base-content/50">You’ll be redirected to Stripe Checkout to finish your subscription securely.</p>
+                  <p class="text-center text-xs text-base-content/50">You'll be redirected to Stripe Checkout to finish your subscription securely.</p>
                 </form>
               )
             ) : (

--- a/src/pages/profile/index.astro
+++ b/src/pages/profile/index.astro
@@ -236,6 +236,7 @@ const csrfToken = getCsrfToken(Astro.cookies);
                   <input type="hidden" name="csrf_token" value={csrfToken} />
                   <button type="submit" class="btn btn-outline btn-sm w-full mt-4">Manage Billing</button>
                 </form>
+                <a href="/profile/invoices" class="btn btn-ghost btn-sm w-full mt-2">View Invoices</a>
               </div>
             ) : (
               <div class="text-center space-y-4 py-2">

--- a/src/pages/profile/invoices.astro
+++ b/src/pages/profile/invoices.astro
@@ -1,0 +1,177 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import Navbar from '../../components/Navbar.astro';
+import Alert from '../../components/ui/Alert.astro';
+import { getSession } from '../../lib/server/auth';
+import { getBillingProfileBySupabaseUserId, getCustomerInvoices, getCurrentSubscriptionRecord } from '../../lib/server/billing';
+
+export const prerender = false;
+
+const authResult = await getSession(Astro, { requireAuth: true });
+if (authResult instanceof Response) return authResult;
+const { user } = authResult;
+
+const profile = await getBillingProfileBySupabaseUserId(user!.id);
+
+if (!profile || !profile.stripeCustomerId) {
+  return Astro.redirect('/profile?billing=no-history');
+}
+
+const subscription = await getCurrentSubscriptionRecord(profile.id);
+const { invoices } = await getCustomerInvoices(profile.stripeCustomerId, { limit: 20 });
+
+const formatCurrency = (amount: number, currency: string) => {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: currency,
+  }).format(amount / 100);
+};
+
+const formatDate = (date: Date) => {
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(date);
+};
+
+const getStatusBadge = (status: string) => {
+  switch (status) {
+    case 'paid':
+      return 'badge-success';
+    case 'open':
+      return 'badge-warning';
+    case 'void':
+    case 'uncollectible':
+      return 'badge-error';
+    default:
+      return 'badge-ghost';
+  }
+};
+---
+
+<Layout title="Invoice History - YouTube Community Portal">
+  <Navbar />
+  <main class="min-h-screen bg-base-200 py-12 px-4 sm:px-6 lg:px-8 mt-16">
+    <div class="max-w-4xl mx-auto space-y-6">
+      
+      <!-- Header -->
+      <div class="flex items-center justify-between">
+        <div>
+          <h1 class="text-3xl font-bold text-base-content">Invoice History</h1>
+          <p class="text-base-content/70 mt-1">View and download your past invoices</p>
+        </div>
+        <a href="/profile" class="btn btn-outline">
+          <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
+          </svg>
+          Back to Profile
+        </a>
+      </div>
+
+      <!-- Current Subscription -->
+      {subscription && (
+        <div class="card bg-base-100 shadow-sm">
+          <div class="card-body">
+            <div class="flex items-center justify-between">
+              <div>
+                <h2 class="card-title text-lg">Current Subscription</h2>
+                <p class="text-base-content/70">
+                  Status: <span class={`badge badge-sm ${subscription.status === 'active' ? 'badge-success' : subscription.status === 'trialing' ? 'badge-info' : 'badge-warning'}`}>
+                    {subscription.status}
+                  </span>
+                </p>
+                {subscription.currentPeriodEnd && (
+                  <p class="text-sm text-base-content/60 mt-1">
+                    {subscription.cancelAtPeriodEnd ? 'Ends' : 'Renews'}: {formatDate(subscription.currentPeriodEnd)}
+                  </p>
+                )}
+              </div>
+              <form method="POST" action="/api/billing/portal">
+                <input type="hidden" name="csrf_token" value={Astro.cookies.get('csrf_token')?.value ?? ''} />
+                <button type="submit" class="btn btn-primary btn-sm">Manage</button>
+              </form>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <!-- Invoice List -->
+      <div class="card bg-base-100 shadow-lg">
+        <div class="card-body">
+          <h2 class="card-title text-xl border-b border-base-300 pb-4">Past Invoices</h2>
+          
+          {invoices.length > 0 ? (
+            <div class="overflow-x-auto">
+              <table class="table table-zebra w-full">
+                <thead>
+                  <tr>
+                    <th>Invoice</th>
+                    <th>Date</th>
+                    <th>Amount</th>
+                    <th>Status</th>
+                    <th class="text-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {invoices.map((invoice) => (
+                    <tr>
+                      <td class="font-mono text-sm">{invoice.number || `#${invoice.id.slice(-8)}`}</td>
+                      <td>{formatDate(invoice.createdAt)}</td>
+                      <td class="font-semibold">{formatCurrency(invoice.amount, invoice.currency)}</td>
+                      <td>
+                        <span class={`badge badge-sm ${getStatusBadge(invoice.status)}`}>
+                          {invoice.status}
+                        </span>
+                      </td>
+                      <td class="text-right">
+                        <div class="flex gap-2 justify-end">
+                          {invoice.invoicePdf && (
+                            <a 
+                              href={invoice.invoicePdf} 
+                              target="_blank" 
+                              rel="noopener noreferrer"
+                              class="btn btn-ghost btn-xs"
+                            >
+                              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+                              </svg>
+                              PDF
+                            </a>
+                          )}
+                          {invoice.invoiceUrl && (
+                            <a 
+                              href={invoice.invoiceUrl} 
+                              target="_blank" 
+                              rel="noopener noreferrer"
+                              class="btn btn-ghost btn-xs"
+                            >
+                              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+                              </svg>
+                              View
+                            </a>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div class="text-center py-12">
+              <svg class="w-16 h-16 text-base-content/30 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+              </svg>
+              <h3 class="text-lg font-semibold text-base-content/70">No invoices yet</h3>
+              <p class="text-base-content/50 mt-1">Your invoice history will appear here once you make a payment.</p>
+              <a href="/pricing" class="btn btn-primary btn-sm mt-4">View Plans</a>
+            </div>
+          )}
+        </div>
+      </div>
+
+    </div>
+  </main>
+</Layout>


### PR DESCRIPTION
## Summary

Adds invoice history and 7-day trial period support to Phase 5 monetization.

## Changes

### Invoice History
- getCustomerInvoices() - List customer invoices from Stripe API
- getCustomerUpcomingInvoice() - Preview upcoming charges
- New /profile/invoices page for invoice history with PDF download
- Profile page now links to Invoice History

### Trial Periods
- createPremiumCheckoutWithTrial() - 7-day trial checkout
- /pricing page now supports trial periods with checkbox
- Trial success messaging on checkout completion

## Progress
- Phase 5: 55% to 70%
- Overall: 66% to 75%

## Test Plan
- [x] Build passes
- [ ] Test invoice history page with real Stripe data
- [ ] Test trial checkout flow
- [ ] Verify trial status shows correctly in subscription